### PR TITLE
HTTP Streams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     'fastapi-users[beanie]',
     'pydantic-settings',
     'uvicorn[standard]',
+    'sse-starlette'
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastapi-users[beanie]==12.1.2
 fastapi==0.103.2
 pydantic-settings==2.0.3
 uvicorn[standard]==0.23.2
+sse-starlette==1.6.5

--- a/src/unipoll_api/routes/__init__.py
+++ b/src/unipoll_api/routes/__init__.py
@@ -5,6 +5,7 @@ from .v1 import router as v1_router
 from .v2 import router as v2_router
 from .swagger_docs import create_doc_router
 from .websocket import router as websocket_router
+from .streams import router as streams_router
 
 
 # Function to generate unique operation IDs for different API versions
@@ -28,6 +29,7 @@ def create_router(app, default_version):
     # Default API version
     router.include_router(endpoints[default_version])
     router.include_router(websocket_router, prefix="/ws", tags=["WebSocket"])
+    router.include_router(streams_router, tags=["Streams"])
 
     # Add API v1 endpoints to the main router
     router.include_router(v1_router,

--- a/src/unipoll_api/routes/streams.py
+++ b/src/unipoll_api/routes/streams.py
@@ -7,7 +7,7 @@ router = APIRouter()
 
 
 @router.get("/updates",
-            response=EventSourceResponse)
+            response_class=EventSourceResponse)
 async def event_log():
     updates = update_generator()
     return EventSourceResponse(updates)

--- a/src/unipoll_api/routes/streams.py
+++ b/src/unipoll_api/routes/streams.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from sse_starlette.sse import EventSourceResponse
+from unipoll_api.utils.streams import update_generator
+
+
+router = APIRouter()
+
+
+@router.get("/updates",
+            response=EventSourceResponse)
+async def event_log():
+    updates = update_generator()
+    return EventSourceResponse(updates)

--- a/src/unipoll_api/utils/streams.py
+++ b/src/unipoll_api/utils/streams.py
@@ -3,7 +3,8 @@ from unipoll_api.documents import Resource
 from . import colored_dbg as Debug
 
 
-async def update_generator(resource: Resource):
+# async def update_generator(resource: Resource):
+async def update_generator():
     i = 0
     try:
         while True:

--- a/src/unipoll_api/utils/streams.py
+++ b/src/unipoll_api/utils/streams.py
@@ -1,0 +1,15 @@
+import asyncio
+from unipoll_api.documents import Resource
+from . import colored_dbg as Debug
+
+
+async def update_generator(resource: Resource):
+    i = 0
+    try:
+        while True:
+            i += 1
+            yield dict(data=i)
+            await asyncio.sleep(0.2)
+    except asyncio.CancelledError as e:
+        Debug.info("Disconnected from client (via refresh/close)")
+        raise e


### PR DESCRIPTION
This pull request introduces server-sent events (SSE) functionality to the project, enabling real-time updates via a new `/updates` endpoint. The changes include adding a new dependency, creating a new route and utility for handling SSE, and integrating the new route into the existing router setup.

### SSE Functionality Implementation:

* **Added `sse-starlette` dependency** to the `pyproject.toml` file to support server-sent events. (`pyproject.toml`, [pyproject.tomlR24](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R24))
* **Created a new `streams` route** in `src/unipoll_api/routes/streams.py`, which defines an SSE endpoint (`/updates`) using `EventSourceResponse`. (`src/unipoll_api/routes/streams.py`, [src/unipoll_api/routes/streams.pyR1-R13](diffhunk://#diff-d1d5ae06e50b7a07fe617eaf947102d7e4d1b50ba009846cee1c28267eb22330R1-R13))
* **Implemented the `update_generator` utility** in `src/unipoll_api/utils/streams.py` to generate real-time updates for the SSE endpoint. (`src/unipoll_api/utils/streams.py`, [src/unipoll_api/utils/streams.pyR1-R16](diffhunk://#diff-c7eeb935dace611340810a858ed94b803699ba4236359a9a58399b48e1ad02d2R1-R16))

### Router Integration:

* **Integrated the `streams` route into the router** by importing it in `src/unipoll_api/routes/__init__.py` and including it in the main router with the tag "Streams". (`src/unipoll_api/routes/__init__.py`, [[1]](diffhunk://#diff-eda4713132eca7163ce4f3e3c8bd932d3e7a9884efed2fbbda3a175638141051R8) [[2]](diffhunk://#diff-eda4713132eca7163ce4f3e3c8bd932d3e7a9884efed2fbbda3a175638141051R32)